### PR TITLE
pymc3 version number is 3 chars ('3.3') not 4

### DIFF
--- a/check_py_stack.ipynb
+++ b/check_py_stack.ipynb
@@ -191,7 +191,7 @@
    ],
    "source": [
     "import pymc3 as pm\n",
-    "float(pm.__version__[:4]) >= 3.3"
+    "float(pm.__version__[:3]) >= 3.3"
    ]
   },
   {


### PR DESCRIPTION
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-17-929b6b216705> in <module>()
      1 import pymc3 as pm
----> 2 float(pm.__version__[:4]) >= 3.3

ValueError: could not convert string to float: '3.4.'